### PR TITLE
change red background to solarized default color for syntax ERROR highlight

### DIFF
--- a/colors/flattened_dark.vim
+++ b/colors/flattened_dark.vim
@@ -28,7 +28,7 @@ hi  DiffChange                              ctermfg=3  ctermbg=0  guifg=#b58900 
 hi  DiffDelete                              ctermfg=1  ctermbg=0  guifg=#dc322f  guibg=#073642  gui=NONE
 hi  DiffText                                ctermfg=4  ctermbg=0  guifg=#268bd2  guibg=#073642  guisp=#268bd2  gui=NONE
 hi  Directory                               ctermfg=4  guifg=#268bd2  gui=NONE
-hi  Error                                   cterm=NONE  ctermfg=1  ctermbg=NONE  guifg=#dc322f  gui=NONE
+hi  Error                                   cterm=NONE  ctermfg=1  ctermbg=NONE  guifg=#dc322f  guibg=#002b36  gui=NONE
 hi  ErrorMsg                                cterm=reverse  ctermfg=1  ctermbg=NONE  guifg=#dc322f  guibg=NONE gui=reverse
 hi  FoldColumn                              ctermfg=12  ctermbg=0  guifg=#839496  guibg=#073642  gui=NONE
 hi  Folded                                  cterm=NONE,underline  ctermfg=12  ctermbg=0  guifg=#839496  guibg=#073642  guisp=#002b36  gui=NONE,underline

--- a/colors/flattened_light.vim
+++ b/colors/flattened_light.vim
@@ -28,7 +28,7 @@ hi DiffChange                              cterm=NONE  ctermfg=3  ctermbg=7  gui
 hi DiffDelete                              cterm=NONE  ctermfg=1  ctermbg=7  gui=NONE  guifg=#dc322f  guibg=#eee8d5  gui=NONE
 hi DiffText                                cterm=NONE  ctermfg=4  ctermbg=7  gui=NONE  guifg=#268bd2  guibg=#eee8d5  guisp=#268bd2  gui=NONE
 hi Directory                               cterm=NONE  ctermfg=4  guifg=#268bd2  gui=NONE
-hi Error                                   cterm=NONE  ctermfg=1  gui=NONE  guifg=#dc322f  gui=NONE
+hi Error                                   cterm=NONE  ctermfg=1  gui=NONE  guifg=#dc322f  guibg=#fdf6e3  gui=NONE
 hi ErrorMsg                                cterm=reverse  ctermfg=1  cterm=NONE  gui=reverse  guifg=#dc322f  guibg=NONE  cterm=NONE
 hi FoldColumn                              cterm=NONE  ctermfg=11  ctermbg=7  guifg=#657b83  guibg=#eee8d5  gui=NONE
 hi Folded                                  cterm=NONE,underline  ctermfg=11  ctermbg=7  gui=NONE,underline  guifg=#657b83  guibg=#eee8d5  guisp=#fdf6e3  gui=NONE


### PR DESCRIPTION
Change the error syntax highlight from 
![old](https://cloud.githubusercontent.com/assets/1390469/13142865/fa917098-d67a-11e5-9248-3f43044f71b7.jpg)
to
![new](https://cloud.githubusercontent.com/assets/1390469/13142872/0347f644-d67b-11e5-865f-96b5aacdcb63.jpg)
in neovim
