### PR TITLE
Remove underline from folds (GUI only).

### DIFF
--- a/colors/flattened_dark.vim
+++ b/colors/flattened_dark.vim
@@ -31,7 +31,7 @@ hi  Directory                               ctermfg=4  guifg=#268bd2  gui=NONE
 hi  Error                                   cterm=NONE  ctermfg=1  ctermbg=NONE  guifg=#dc322f  guibg=#002b36  gui=NONE
 hi  ErrorMsg                                cterm=reverse  ctermfg=1  ctermbg=NONE  guifg=#dc322f  guibg=NONE gui=reverse
 hi  FoldColumn                              ctermfg=12  ctermbg=0  guifg=#839496  guibg=#073642  gui=NONE
-hi  Folded                                  cterm=NONE,underline  ctermfg=12  ctermbg=0  guifg=#839496  guibg=#073642  guisp=#002b36  gui=NONE,underline
+hi  Folded                                  cterm=NONE,underline  ctermfg=12  ctermbg=0  guifg=#839496  guibg=#073642  guisp=#002b36  gui=NONE
 hi  HelpExample                             ctermfg=14  guifg=#93a1a1  gui=NONE
 hi  Identifier                              ctermfg=4  guifg=#268bd2  gui=NONE
 hi  IncSearch                               cterm=standout  ctermfg=9  guifg=#cb4b16  gui=standout

--- a/colors/flattened_light.vim
+++ b/colors/flattened_light.vim
@@ -31,7 +31,7 @@ hi Directory                               cterm=NONE  ctermfg=4  guifg=#268bd2 
 hi Error                                   cterm=NONE  ctermfg=1  gui=NONE  guifg=#dc322f  guibg=#fdf6e3  gui=NONE
 hi ErrorMsg                                cterm=reverse  ctermfg=1  cterm=NONE  gui=reverse  guifg=#dc322f  guibg=NONE  cterm=NONE
 hi FoldColumn                              cterm=NONE  ctermfg=11  ctermbg=7  guifg=#657b83  guibg=#eee8d5  gui=NONE
-hi Folded                                  cterm=NONE,underline  ctermfg=11  ctermbg=7  gui=NONE,underline  guifg=#657b83  guibg=#eee8d5  guisp=#fdf6e3  gui=NONE
+hi Folded                                  cterm=NONE,underline  ctermfg=11  ctermbg=7  guifg=#657b83  guibg=#eee8d5  guisp=#fdf6e3  gui=NONE
 hi HelpExample                             cterm=NONE  ctermfg=10  guifg=#586e75  gui=NONE
 hi Identifier                              cterm=NONE  ctermfg=4  guifg=#268bd2  gui=NONE
 hi IncSearch                               cterm=standout  ctermfg=9  gui=standout  guifg=#cb4b16


### PR DESCRIPTION
This repository doesn't seem to have an _Issues_ section, so I went ahead and did it before asking for an opinion. We can discuss the topic here if the maintainer disagrees with my choice.

In GUI mode, which also includes Neovim's true colour mode, the text of folds appears with an underline. Solarized doesn't do that in GUI mode and in my opinion it just adds visual noise. Folds are already differently coloured, so there should be no need for an extra underline. Furthermore, the underline was only showing in the dark variant, not the light one, so one of them has to be the defective one.

Let me know what you think and if you agree or disagree.
