### PR TITLE
Remove yellow background from 'TODO' items.

### DIFF
--- a/colors/flattened_dark.vim
+++ b/colors/flattened_dark.vim
@@ -61,7 +61,7 @@ hi  TabLine                                 cterm=underline  ctermfg=12  ctermbg
 hi  TabLineFill                             cterm=underline  ctermfg=12  ctermbg=0  guifg=#839496  guibg=#073642  guisp=#839496  gui=underline
 hi  TabLineSel                              cterm=underline,reverse  ctermfg=10  ctermbg=7  guifg=#586e75  guibg=#eee8d5  guisp=#839496  gui=underline,reverse
 hi  Title                                   cterm=NONE  ctermfg=9  guifg=#cb4b16  gui=NONE
-hi  Todo                                    cterm=NONE  ctermfg=5  guifg=#d33682  gui=NONE
+hi  Todo                                    cterm=NONE  ctermfg=5  guifg=#d33682  guibg=NONE  gui=bold
 hi  Type                                    ctermfg=3  guifg=#b58900  gui=NONE
 hi  Underlined                              ctermfg=13  guifg=#6c71c4  gui=NONE
 hi  VarId                                   ctermfg=4  guifg=#268bd2  gui=NONE

--- a/colors/flattened_light.vim
+++ b/colors/flattened_light.vim
@@ -60,8 +60,8 @@ hi StatusLineNC                            cterm=reverse  ctermfg=12  ctermbg=7 
 hi TabLine                                 cterm=underline  ctermfg=11  ctermbg=7  gui=underline  guifg=#657b83  guibg=#eee8d5  guisp=#657b83
 hi TabLineFill                             cterm=underline  ctermfg=11  ctermbg=7  gui=underline  guifg=#657b83  guibg=#eee8d5  guisp=#657b83
 hi TabLineSel                              cterm=underline,reverse  ctermfg=14  ctermbg=0  gui=underline,reverse  guifg=#93a1a1  guibg=#073642  guisp=#657b83
-hi Title                                   cterm=NONE  ctermfg=9  gui=NONE  guifg=#cb4b16  gui=NONE
-hi Todo                                    cterm=NONE  ctermfg=5  gui=NONE  guifg=#d33682  gui=NONE
+hi Title                                   cterm=NONE  ctermfg=9  guifg=#cb4b16  gui=NONE
+hi Todo                                    cterm=NONE  ctermfg=5  guifg=#d33682  guibg=NONE gui=bold
 hi Type                                    cterm=NONE  ctermfg=3  guifg=#b58900  gui=NONE
 hi Underlined                              cterm=NONE  ctermfg=13  guifg=#6c71c4  gui=NONE
 hi VarId                                   cterm=NONE  ctermfg=4  guifg=#268bd2  gui=NONE


### PR DESCRIPTION
The yellow background of `TODO` items does not exist in the original and it's really ugly.

@romainl I can see quite a few more problems with this colour scheme, if you don't want to maintain it yourself I would be willing to take over the project since I am actively using it. I don't see any license to it, so I can't just fork and and run with it on my own.
