### PR TITLE
Add colors for neovim's terminal

### DIFF
--- a/colors/flattened_dark.vim
+++ b/colors/flattened_dark.vim
@@ -304,3 +304,22 @@ hi clear SyntasticWarningLine
 hi clear helpLeadBlank
 hi clear helpNormal
 hi clear pandocTableStructre
+
+if has('nvim')
+  let g:terminal_color_0  = '#073642'
+  let g:terminal_color_1  = '#dc322f'
+  let g:terminal_color_2  = '#859900'
+  let g:terminal_color_3  = '#b58900'
+  let g:terminal_color_4  = '#268bd2'
+  let g:terminal_color_5  = '#d33682'
+  let g:terminal_color_6  = '#2aa198'
+  let g:terminal_color_7  = '#eee8d5'
+  let g:terminal_color_8  = '#002b36'
+  let g:terminal_color_9  = '#cb4b16'
+  let g:terminal_color_10 = '#586e75'
+  let g:terminal_color_11 = '#657b83'
+  let g:terminal_color_12 = '#839496'
+  let g:terminal_color_13 = '#6c71c4'
+  let g:terminal_color_14 = '#93a1a1'
+  let g:terminal_color_15 = '#fdf6e3'
+endif

--- a/colors/flattened_light.vim
+++ b/colors/flattened_light.vim
@@ -293,3 +293,22 @@ hi clear SyntasticWarningLine
 hi clear helpLeadBlank
 hi clear helpNormal
 hi clear pandocTableStructre
+
+if has('nvim')
+  let g:terminal_color_0  = '#eee8d5'
+  let g:terminal_color_1  = '#dc322f'
+  let g:terminal_color_2  = '#859900'
+  let g:terminal_color_3  = '#b58900'
+  let g:terminal_color_4  = '#268bd2'
+  let g:terminal_color_5  = '#d33682'
+  let g:terminal_color_6  = '#2aa198'
+  let g:terminal_color_7  = '#073642'
+  let g:terminal_color_8  = '#fdf6e3'
+  let g:terminal_color_9  = '#cb4b16'
+  let g:terminal_color_10 = '#93a1a1'
+  let g:terminal_color_11 = '#839496'
+  let g:terminal_color_12 = '#657b83'
+  let g:terminal_color_13 = '#6c71c4'
+  let g:terminal_color_14 = '#586e75'
+  let g:terminal_color_15 = '#002b36'
+endif


### PR DESCRIPTION
Simple patch to Solarize the `:terminal` in neovim when `termguicolors` is set.

Please let me know if you have any concerns.
