### PR TITLE
fix Todo highlight

### DIFF
--- a/colors/flattened_dark.vim
+++ b/colors/flattened_dark.vim
@@ -61,7 +61,7 @@ hi  TabLine                                 cterm=underline  ctermfg=12  ctermbg
 hi  TabLineFill                             cterm=underline  ctermfg=12  ctermbg=0  guifg=#839496  guibg=#073642  guisp=#839496  gui=underline
 hi  TabLineSel                              cterm=underline,reverse  ctermfg=10  ctermbg=7  guifg=#586e75  guibg=#eee8d5  guisp=#839496  gui=underline,reverse
 hi  Title                                   cterm=NONE  ctermfg=9  guifg=#cb4b16  gui=NONE
-hi  Todo                                    cterm=bold  ctermfg=5  guifg=#d33682  guibg=NONE  gui=bold
+hi  Todo                                    cterm=bold  ctermfg=5  ctermbg=8  guifg=#d33682  guibg=NONE  gui=bold
 hi  Type                                    cterm=NONE  ctermfg=3  guifg=#b58900  gui=NONE
 hi  Underlined                              cterm=NONE  ctermfg=13  guifg=#6c71c4  gui=NONE
 hi  VarId                                   cterm=NONE  ctermfg=4  guifg=#268bd2  gui=NONE

--- a/colors/flattened_light.vim
+++ b/colors/flattened_light.vim
@@ -61,7 +61,7 @@ hi TabLine                                 cterm=underline  ctermfg=11  ctermbg=
 hi TabLineFill                             cterm=underline  ctermfg=11  ctermbg=7  gui=underline  guifg=#657b83  guibg=#eee8d5  guisp=#657b83
 hi TabLineSel                              cterm=underline,reverse  ctermfg=14  ctermbg=0  gui=underline,reverse  guifg=#93a1a1  guibg=#073642  guisp=#657b83
 hi Title                                   cterm=NONE  ctermfg=9  guifg=#cb4b16  gui=NONE
-hi Todo                                    cterm=NONE  ctermfg=5  guifg=#d33682  guibg=NONE gui=bold
+hi Todo                                    cterm=bold  ctermfg=5  ctermbg=15  guifg=#d33682  guibg=NONE gui=bold
 hi Type                                    cterm=NONE  ctermfg=3  guifg=#b58900  gui=NONE
 hi Underlined                              cterm=NONE  ctermfg=13  guifg=#6c71c4  gui=NONE
 hi VarId                                   cterm=NONE  ctermfg=4  guifg=#268bd2  gui=NONE


### PR DESCRIPTION
1. normalize dark/light variants: light Todo hi now bold too

2. explicitly set the ctermbg correctly. For some reason the ctermbg was
   being set to 11 for me. (causing it to be almost unreadable)

   I'm still not sure exactly why the `ctermbg` was being set oddly - I
   couldn't determine the source and it seems that other highlight groups
   declared similarly to Todo were unaffected. There may be a better
   fix, or perhaps something strange is happening on my system.