### PR TITLE
Use Normal background for Conceal

### DIFF
--- a/colors/flattened_dark.vim
+++ b/colors/flattened_dark.vim
@@ -17,7 +17,7 @@ set background=dark
 hi  ColorColumn                             cterm=NONE  ctermbg=0  guibg=#073642  gui=NONE
 hi  Comment                                 cterm=NONE  ctermfg=10  guifg=#586e75  gui=italic
 hi  ConId                                   cterm=NONE  ctermfg=3  guifg=#b58900  gui=NONE
-hi  Conceal                                 cterm=NONE  ctermfg=4  guifg=#268bd2  gui=NONE
+hi  Conceal                                 cterm=NONE  ctermfg=4  ctermbg=8  guifg=#268bd2  guibg=#002b36  gui=NONE
 hi  Constant                                cterm=NONE  ctermfg=6  guifg=#2aa198  gui=NONE
 hi  Cursor                                  cterm=NONE  ctermfg=8  ctermbg=12  guifg=#002b36  guibg=#839496  gui=NONE
 hi  CursorColumn                            cterm=NONE  ctermbg=0  guibg=#073642  gui=NONE

--- a/colors/flattened_light.vim
+++ b/colors/flattened_light.vim
@@ -17,7 +17,7 @@ set background=light
 hi ColorColumn                             cterm=NONE  ctermbg=7  guibg=#eee8d5  gui=NONE
 hi Comment                                 cterm=NONE  ctermfg=14 guifg=#93a1a1  gui=italic
 hi ConId                                   cterm=NONE  ctermfg=3  guifg=#b58900  gui=NONE
-hi Conceal                                 cterm=NONE  ctermfg=4  guifg=#268bd2  gui=NONE
+hi Conceal                                 cterm=NONE  ctermfg=4  ctermbg=15  guifg=#268bd2  guibg=#fdf6e3  gui=NONE
 hi Constant                                cterm=NONE  ctermfg=6  guifg=#2aa198  gui=NONE
 hi Cursor                                  cterm=NONE  ctermfg=15  ctermbg=11  guifg=#fdf6e3  guibg=#657b83  gui=NONE
 hi CursorColumn                            cterm=NONE  ctermbg=7  guibg=#eee8d5  gui=NONE


### PR DESCRIPTION
I don't know if it was intended for some purpose, but I found the greyish background of Conceal highlighting a bit unpleasant. with vim-pandoc-syntax for example I end up with big grey boxes around headline characters like `#` or `##` and bullet points. Explicitely specifying the Normal background used in the dark/light versions makes it look more consistent imho.

Feel free to reject the PR if the changes would break intended highlighting in some other use case.